### PR TITLE
Remove net/http normalization

### DIFF
--- a/lib/faraday_middleware/request/aws_sigv4.rb
+++ b/lib/faraday_middleware/request/aws_sigv4.rb
@@ -18,10 +18,6 @@ class FaradayMiddleware::AwsSigV4 < Faraday::Middleware
   private
 
   def sign!(env)
-    if net_http_adapter?
-      normalize_for_net_http!(env)
-    end
-
     request = build_aws_sigv4_request(env)
     signature = @signer.sign_request(request)
 
@@ -35,9 +31,5 @@ class FaradayMiddleware::AwsSigV4 < Faraday::Middleware
       headers: env.request_headers,
       body: env.body,
     }
-  end
-
-  def net_http_adapter?
-    @app.is_a?(Faraday::Adapter::NetHttp)
   end
 end

--- a/lib/faraday_middleware/request/aws_sigv4_util.rb
+++ b/lib/faraday_middleware/request/aws_sigv4_util.rb
@@ -1,17 +1,4 @@
 module FaradayMiddleware::AwsSigV4Util
-  def normalize_for_net_http!(env)
-    # `net/http` forcibly adds a `Accept-Encoding` header.
-    # see https://github.com/ruby/ruby/blob/v2_4_2/lib/net/http/generic_request.rb#L39
-    # If you do not want you to add a `Accept-Encoding` header,
-    # explicitly set the header or use an adapter other than `net/http`.
-    if Net::HTTP::HAVE_ZLIB
-      env.request_headers['Accept-Encoding'] ||= 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3'
-    end
-
-    env.request_headers['Accept'] ||= '*/*'
-    env
-  end
-
   def seahorse_encode_query(url)
     return url unless url.query
 

--- a/spec/faraday_middleware/aws_sigv4_spec.rb
+++ b/spec/faraday_middleware/aws_sigv4_spec.rb
@@ -70,10 +70,6 @@ RSpec.describe FaradayMiddleware::AwsSigV4 do
     end
   end
 
-  before do
-    stub_const('Net::HTTP::HAVE_ZLIB', true)
-  end
-
   context 'without query' do
     let(:signature) do
       '9a2e392463d9ecfd5e514b181d82d3d271cd9ad9e7ea310ee1590d161882fece'
@@ -106,28 +102,5 @@ RSpec.describe FaradayMiddleware::AwsSigV4 do
 
       it { is_expected.to eq response }
     end
-  end
-
-  context 'use net/http adapter' do
-    subject { client.get('/account').body }
-
-    let(:signature) do
-      '6a8a8da84ee1dc8ca7ed102efe5db92c58920c858c46d8a9e7fea1d0cace2888'
-    end
-
-    let(:signed_headers) do
-      'accept;accept-encoding;host;user-agent;x-amz-content-sha256;x-amz-date'
-    end
-
-    let(:additional_expected_headers) do
-      {'Accept'=>'*/*',
-       'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3'}
-    end
-
-    before do
-      expect_any_instance_of(FaradayMiddleware::AwsSigV4).to receive(:net_http_adapter?).and_return(true)
-    end
-
-    it { is_expected.to eq response }
   end
 end

--- a/spec/faraday_middleware/aws_sigv4_util_spec.rb
+++ b/spec/faraday_middleware/aws_sigv4_util_spec.rb
@@ -5,34 +5,6 @@ RSpec.describe FaradayMiddleware::AwsSigV4Util do
     end
   end
 
-  describe '#normalize_for_net_http!' do
-    let(:env) { OpenStruct.new(request_headers: {}) }
-
-    subject do
-      class_with_util.new.normalize_for_net_http!(env)
-      env.request_headers
-    end
-
-    context 'have zlib' do
-      before do
-        stub_const('Net::HTTP::HAVE_ZLIB', true)
-      end
-
-      it {
-        is_expected.to match(
-          'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3')
-      }
-    end
-
-    context 'have no zlib' do
-      before do
-        stub_const('Net::HTTP::HAVE_ZLIB', false)
-      end
-
-      it { is_expected.to match('Accept' => '*/*') }
-    end
-  end
-
   describe '#seahorse_encode_query' do
     subject do
       class_with_util.new.seahorse_encode_query(url).query


### PR DESCRIPTION
Since `net/http` automatically adds `Accept`/`AcceptEncoding` headers, I thought that it was necessary to add it to the signature.

However it seems unnecessary..
https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html

> 5. Add the signed headers, followed by a newline character. This value is the list of headers that you included in the canonical headers. By adding this list of headers, you tell AWS which headers in the request are part of the signing process and which ones AWS can ignore (for example, any additional headers added by a proxy) for purposes of validating the request.

So I will delete this unnecessary process.