### PR TITLE
Update documentation to note upgrade changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ pp res.body
 #    "throttleSettings"=>{"rateLimit"=>10000.0, "burstLimit"=>5000}}
 ```
 
+## Upgrading from `faraday_middleware-aws-signers-v4`
+
+If you previously provided the `service_name` option, you need ot rename it `service`
+
 ## Related Links
 
 * http://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/Sigv4/Signer.html

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ pp res.body
 
 ## Upgrading from `faraday_middleware-aws-signers-v4`
 
-If you previously provided the `service_name` option, you need ot rename it `service`
+If you previously provided the `service_name` option, you need to rename it `service`
 
 ## Related Links
 


### PR DESCRIPTION
When upgrading from the old gem, `service_name` needs to be renamed to `service`. I think it's important to note that but definitely open to wording changes etc.