### PR TITLE
Fix: Pin Faraday dependency so that this gem still supports older versions of Ruby.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ rvm:
 - 2.4.3
 - 2.5.0
 before_install:
-- gem update --system
+- gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+- gem install bundler -v '< 2'
 script:
 - bundle exec rake
 gemfile:

--- a/faraday_middleware-aws-sigv4.gemspec
+++ b/faraday_middleware-aws-sigv4.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'faraday_middleware-aws-sigv4'
-  spec.version       = '0.2.4'
+  spec.version       = '0.2.5'
   spec.authors       = ['Genki Sugawara']
   spec.email         = ['sugawara@cookpad.com']
 
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', '>= 0.9'
+  spec.add_dependency 'faraday', '>= 0.9', '<= 0.14.0'
   spec.add_dependency 'aws-sigv4', '~> 1.0'
 
   spec.add_development_dependency 'faraday_middleware'

--- a/faraday_middleware-aws-sigv4.gemspec
+++ b/faraday_middleware-aws-sigv4.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'timecop'
   spec.add_development_dependency 'coveralls'
-  spec.add_development_dependency 'aws-sdk-core', '~> 3.0'
+  spec.add_development_dependency 'aws-sdk-core', '~> 3.14.0'
   spec.add_development_dependency 'appraisal', '>= 2.2'
 end


### PR DESCRIPTION
### What have I changed?
- Bump version to 0.2.5
- Pin Faraday to 0.14.0 as 0.15.x breaks the tests and 0.16.x only supports Ruby
2.3.0 and above.
- Pin version of aws-sdk-core as the way they handle time has changed. https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sdk-core/lib/aws-sdk-
core/instance_profile_credentials.rb\#L81
- Fix: Pin Faraday dependency so that this gem still supports older versions of Ruby.

### Testing done
Ran the rspec tests locally.

### Why are you making this change?
We currently have a lot of our production instances relying on this Gem. The instances are currently running Ruby 2.2. Faradays latest release has essentially dropped support for versions of ruby less than 2.3. I'm hoping to have this change merged to reduce the impact of the Faraday change on the consumers of this gem.