### PR TITLE
Change 'faraday_middleware' to runtime dependency

### DIFF
--- a/faraday_middleware-aws-sigv4.gemspec
+++ b/faraday_middleware-aws-sigv4.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'faraday', '>= 0.15'
   spec.add_dependency 'aws-sigv4', '~> 1.0'
-
-  spec.add_development_dependency 'faraday_middleware'
+  spec.add_dependency 'faraday_middleware', '>= 0.12'
+  
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
In the README, it is documented that this gem needs "faraday_middleware" gem installed.
We should make it a runtime dependency so that people don't have to specify it explicitly, or don't accidentally remove "faraday_middleware"

For the context: in our repo, we have "faraday_middleware" installed because it's the dependency of another gem. When we removed that gem we almost accidentally remove "faraday_middleware". Only upon reading README of "faraday_middleware-aws-sigv4" do we realize it is still needed