### PR TITLE
Instantiate signer for each request

### DIFF
--- a/lib/faraday_middleware/request/aws_sigv4.rb
+++ b/lib/faraday_middleware/request/aws_sigv4.rb
@@ -9,7 +9,6 @@ module FaradayMiddleware
 
     def initialize(app, options = nil)
       super(app)
-      @signer = Aws::Sigv4::Signer.new(options)
       @options = options
     end
 
@@ -22,7 +21,9 @@ module FaradayMiddleware
 
     def sign!(env)
       request = build_aws_sigv4_request(env)
-      signature = @signer.sign_request(request)
+
+      signer = Aws::Sigv4::Signer.new(@options)
+      signature = signer.sign_request(request)
 
       signature.headers.each do |name, value|
         env.request_headers[name] = value


### PR DESCRIPTION
We are having issues where after a period of time (24 hours or so) we start getting errors about the signature having expired. My current theory is that this is because the `Signer` is only instantiated once in the initializer.

This PR changes this so the `Signer` is initialized on every call. This maps more closely with the way the original `faraday_middleware-aws-signers-v4` gem worked.