### PR TITLE
Add funding_uri to gemspec

### DIFF
--- a/faraday_middleware-aws-sigv4.gemspec
+++ b/faraday_middleware-aws-sigv4.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'timecop'
 
   spec.metadata = {
-    'rubygems_mfa_required' => 'true'
+    'rubygems_mfa_required' => 'true',
+    'funding_uri' => 'https://github.com/sponsors/winebarrel'
   }
 end


### PR DESCRIPTION
I noticed that your on GitHub Sponsors. This PR adds the `funding_uri` to your gemspec to help increase visibility using the `bundle fund` command in Bundler.